### PR TITLE
feat: Implement 'select and use' item mechanic

### DIFF
--- a/player.tscn
+++ b/player.tscn
@@ -13,14 +13,25 @@ const SPEED = 100.0
 @onready var animated_sprite: AnimatedSprite2D = $AnimatedSprite2D
 @onready var inventory: Inventory = $Inventory
 @onready var inventory_ui: CanvasLayer = $InventoryUI
+@onready var hand_sprite: Sprite2D = $HandSprite
+
+var current_item: Item = null
 
 func _ready():
 	inventory_ui.set_inventory(inventory)
+	inventory_ui.item_selected.connect(_on_item_selected)
+	hand_sprite.visible = false
 
 func _unhandled_input(event):
 	if event.is_action_pressed(\"toggle_inventory\"):
 		inventory_ui.toggle()
 		get_viewport().set_input_as_handled()
+		return
+
+	if event.is_action_pressed("use_item"):
+		if current_item:
+			use_current_item()
+			get_viewport().set_input_as_handled()
 
 func _physics_process(delta):
 	var input_vector = Vector2(
@@ -45,6 +56,36 @@ func get_direction_name(vec: Vector2) -> String:
 
 func get_inventory() -> Inventory:
 	return inventory
+
+func _on_item_selected(item: Item):
+	current_item = item
+	if current_item:
+		hand_sprite.texture = current_item.texture
+		hand_sprite.visible = true
+	else:
+		hand_sprite.visible = false
+
+func use_current_item():
+	if not current_item:
+		return
+
+	match current_item.item_type:
+		Item.ItemType.CONSUMABLE:
+			print("Consumed item: " + current_item.name)
+			var selected_slot = inventory_ui.selected_slot
+			if selected_slot != -1:
+				inventory.remove_item(selected_slot)
+
+		Item.ItemType.SEED:
+			print("Planted seed: " + current_item.name)
+			# Placeholder for planting logic
+			var selected_slot = inventory_ui.selected_slot
+			if selected_slot != -1:
+				inventory.remove_item(selected_slot)
+
+		Item.ItemType.TOOL:
+			print("Used tool: " + current_item.name)
+			# Tool is not consumed.
 "
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_onrkg"]
@@ -291,3 +332,7 @@ shape = SubResource("RectangleShape2D_4flbx")
 script = ExtResource("3_inv")
 
 [node name="InventoryUI" parent="." instance=ExtResource("2_ui")]
+
+[node name="HandSprite" type="Sprite2D" parent="."]
+z_index = 1
+position = Vector2(8, -8)

--- a/project.godot
+++ b/project.godot
@@ -42,6 +42,11 @@ toggle_inventory={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":73,"key_label":0,"unicode":105,"location":0,"echo":false,"script":null)
 ]
 }
+use_item={
+"deadzone": 0.2,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"button_index":1,"double_click":false,"script":null)
+]
+}
 
 [rendering]
 

--- a/scripts/Collectible.gd
+++ b/scripts/Collectible.gd
@@ -9,7 +9,7 @@ func _ready():
         # This is a workaround for not being able to create .tres files easily.
         var new_item = Item.new()
         new_item.name = "Tomato"
-        new_item.consumable = true
+        new_item.item_type = Item.ItemType.CONSUMABLE
         new_item.stackable = true
         # We still have the texture problem.
         # I'll load the spritesheet and maybe I can create an AtlasTexture in code.

--- a/scripts/Inventory.gd
+++ b/scripts/Inventory.gd
@@ -34,5 +34,5 @@ func use_item(slot: int):
         # Here you would add the logic for using the item
         print("Using item: " + item.name)
 
-        if item.consumable:
+        if item.item_type == Item.ItemType.CONSUMABLE or item.item_type == Item.ItemType.SEED:
             remove_item(slot)

--- a/scripts/resources/Item.gd
+++ b/scripts/resources/Item.gd
@@ -2,7 +2,9 @@
 extends Resource
 class_name Item
 
+enum ItemType { TOOL, CONSUMABLE, SEED }
+
 @export var name: String = ""
 @export var texture: Texture2D
 @export var stackable: bool = false
-@export var consumable: bool = false
+@export var item_type: ItemType = ItemType.CONSUMABLE

--- a/scripts/ui/InventoryUI.gd
+++ b/scripts/ui/InventoryUI.gd
@@ -1,14 +1,40 @@
 # scripts/ui/InventoryUI.gd
 extends CanvasLayer
 
+signal item_selected(item: Item)
+
 @onready var grid_container = $MarginContainer/Panel/GridContainer
 var inventory: Inventory
 
+var selected_slot = -1
+var selected_stylebox: StyleBoxFlat
+var default_stylebox: StyleBoxFlat
+
+
 func _ready():
+    # Create styleboxes for selection feedback
+    default_stylebox = StyleBoxFlat.new()
+    default_stylebox.bg_color = Color(0.2, 0.2, 0.2, 0.5)
+    default_stylebox.border_width_left = 1
+    default_stylebox.border_width_top = 1
+    default_stylebox.border_width_right = 1
+    default_stylebox.border_width_bottom = 1
+    default_stylebox.border_color = Color(0.5, 0.5, 0.5, 1)
+
+    selected_stylebox = StyleBoxFlat.new()
+    selected_stylebox.bg_color = Color(0.4, 0.4, 0.2, 0.5)
+    selected_stylebox.border_width_left = 2
+    selected_stylebox.border_width_top = 2
+    selected_stylebox.border_width_right = 2
+    selected_stylebox.border_width_bottom = 2
+    selected_stylebox.border_color = Color(1, 1, 0, 1)
+
     # Create the visual slots
     for i in range(10):
         var slot = Panel.new()
         slot.custom_minimum_size = Vector2(32, 32)
+        slot.set("theme_override_styles/panel", default_stylebox)
+        slot.gui_input.connect(_on_slot_gui_input.bind(i))
         grid_container.add_child(slot)
 
     hide() # Start hidden
@@ -19,6 +45,10 @@ func set_inventory(inv: Inventory):
     _update_display()
 
 func _on_inventory_changed():
+    # If the selected item was removed, deselect it
+    if selected_slot != -1 and inventory.items[selected_slot] == null:
+        selected_slot = -1
+        item_selected.emit(null)
     _update_display()
 
 func _update_display():
@@ -39,9 +69,37 @@ func _update_display():
             slot_visual.add_child(item_texture)
             item_texture.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 
+    _update_selection_visuals()
+
+func _on_slot_gui_input(event: InputEvent, slot_index: int):
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.is_pressed():
+        # If clicking the already selected slot, deselect it
+        if selected_slot == slot_index:
+            selected_slot = -1
+            item_selected.emit(null)
+        else:
+            selected_slot = slot_index
+            item_selected.emit(inventory.items[selected_slot])
+
+        _update_selection_visuals()
+
+func _update_selection_visuals():
+    for i in range(grid_container.get_child_count()):
+        var slot_visual = grid_container.get_child(i)
+        if i == selected_slot:
+            slot_visual.set("theme_override_styles/panel", selected_stylebox)
+        else:
+            slot_visual.set("theme_override_styles/panel", default_stylebox)
+
 
 func toggle():
     visible = not visible
+    # When closing the inventory, also deselect the item
+    if not visible:
+        if selected_slot != -1:
+            selected_slot = -1
+            item_selected.emit(null)
+            _update_selection_visuals()
 
 
 func _unhandled_input(event):


### PR DESCRIPTION
This commit introduces the ability for the player to select items from the inventory and use them in the game world.

- The `Item` resource now has an `ItemType` enum (`TOOL`, `CONSUMABLE`, `SEED`) to differentiate item behaviors.
- The Inventory UI now supports clicking on slots to select an item. The selected slot is visually highlighted, and a signal is emitted to the player.
- The Player character now has a `HandSprite` to visually display the selected item.
- A `use_item` input action (left mouse click) is added.
- The player script now handles the `use_item` action, performing different logic based on the selected item's type:
    - Consumables and Seeds are removed from the inventory upon use.
    - Tools are not consumed.