### PR TITLE
Refactor the item system to be resource-based and categorized.

### DIFF
--- a/item.tscn
+++ b/item.tscn
@@ -1,24 +1,18 @@
-[gd_scene load_steps=2 format=3 uid="uid://c6xwx520gwayh"]
+[gd_scene load_steps=4 format=3 uid="uid://c6xwx520gwayh"]
 
-[sub_resource type="GDScript" id="GDScript_vpy52"]
-script/source = "extends Area2D
+[ext_resource type="Script" path="res://scripts/Collectible.gd" id="1_vpy52"]
+[ext_resource type="Resource" path="res://scripts/resources/Tomato.tres" id="2_tomato"]
 
-@export var item_texture: Texture
-
-func _ready():
-	$Sprite2D.texture = item_texture
-
-func _on_body_entered(body):
-	if body.name == \"Player\":
-		body.get_node(\"InventoryUI\").add_item(item_texture)
-		queue_free()  # Remove o item do chão
-"
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_abcde"]
+size = Vector2(16, 16)
 
 [node name="Item" type="Area2D"]
-script = SubResource("GDScript_vpy52")
+script = ExtResource("1_vpy52")
+item = ExtResource("2_tomato")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_abcde")
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/scripts/Collectible.gd
+++ b/scripts/Collectible.gd
@@ -4,21 +4,10 @@ extends Area2D
 @export var item: Item
 
 func _ready():
-    if not item:
-        # Create a default item if none is assigned.
-        # This is a workaround for not being able to create .tres files easily.
-        var new_item = Item.new()
-        new_item.name = "Tomato"
-        new_item.item_type = Item.ItemType.CONSUMABLE
-        new_item.stackable = true
-        # We still have the texture problem.
-        # I'll load the spritesheet and maybe I can create an AtlasTexture in code.
-        var full_texture = load("res://assets/itens/Crop_Spritesheet.png")
-        var atlas_texture = AtlasTexture.new()
-        atlas_texture.atlas = full_texture
-        atlas_texture.region = Rect2(0, 32, 16, 16) # The grown tomato sprite
-        new_item.texture = atlas_texture
-        item = new_item
+    if item and item.texture:
+        var sprite = get_node_or_null("Sprite2D")
+        if sprite:
+            sprite.texture = item.texture
 
 func _on_body_entered(body: Node2D):
     if body.has_method("get_inventory"):

--- a/scripts/Inventory.gd
+++ b/scripts/Inventory.gd
@@ -31,8 +31,21 @@ func remove_item(slot: int):
 func use_item(slot: int):
     if slot >= 0 and slot < items.size() and items[slot] != null:
         var item = items[slot]
-        # Here you would add the logic for using the item
         print("Using item: " + item.name)
 
-        if item.item_type == Item.ItemType.CONSUMABLE or item.item_type == Item.ItemType.SEED:
-            remove_item(slot)
+        match item.item_type:
+            Item.ItemType.FOOD:
+                get_parent().get_node("Stats").eat(item.health_restored)
+                remove_item(slot)
+            Item.ItemType.POTION:
+                # Logic for using potion
+                remove_item(slot)
+            Item.ItemType.SEED:
+                # Logic for using seed
+                remove_item(slot)
+            Item.ItemType.TOOL:
+                # Logic for using tool
+                pass
+            Item.ItemType.OTHER:
+                # Logic for using other
+                pass

--- a/scripts/resources/Item.gd
+++ b/scripts/resources/Item.gd
@@ -2,9 +2,20 @@
 extends Resource
 class_name Item
 
-enum ItemType { TOOL, CONSUMABLE, SEED }
+enum ItemType { FOOD, POTION, TOOL, SEED, OTHER }
+enum ToolType { STAFF, SWORD, HOE, WATERING_CAN, SCYTHE }
 
 @export var name: String = ""
 @export var texture: Texture2D
 @export var stackable: bool = false
-@export var item_type: ItemType = ItemType.CONSUMABLE
+@export var item_type: ItemType = ItemType.FOOD
+
+# Food properties
+@export var health_restored: int = 0
+@export var energy_restored: int = 0
+
+# Potion properties
+@export var effects: Dictionary = {}
+
+# Tool properties
+@export var tool_type: ToolType

--- a/scripts/resources/Tomato.tres
+++ b/scripts/resources/Tomato.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="Item" load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/resources/Item.gd" id="1_item_script"]
+[ext_resource type="Texture2D" uid="uid://caak753wfxepn" path="res://assets/itens/Crop_Spritesheet.png" id="2_crop_spritesheet"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_tomato"]
+atlas = ExtResource("2_crop_spritesheet")
+region = Rect2(0, 32, 16, 16)
+
+[resource]
+script = ExtResource("1_item_script")
+name = "Tomato"
+texture = SubResource("AtlasTexture_tomato")
+stackable = true
+item_type = 0 # FOOD
+health_restored = 10
+energy_restored = 5
+effects = {}
+tool_type = 1 # SWORD (default, not used for food)


### PR DESCRIPTION
This change refactors the item system to use Godot's `Resource` class, making it more flexible and easier to manage.

Key changes:
- Replaced the hardcoded 'tomate' node with a generic `item.tscn` scene that uses a `Collectible.gd` script.
- Created a new `Item.gd` script that defines an item as a `Resource`.
- Introduced an `ItemType` enum to categorize items into: `FOOD`, `POTION`, `TOOL`, `SEED`, and `OTHER`.
- Added specific properties for each item type, such as `health_restored` for food and `tool_type` for tools.
- Updated the `Inventory.gd` script to handle the different item types when an item is used.
- Created a `Tomato.tres` resource as an example of a food item.