### PR TITLE
feat: Add hotkeys to select inventory items

### DIFF
--- a/player.tscn
+++ b/player.tscn
@@ -32,6 +32,16 @@ func _unhandled_input(event):
 		if current_item:
 			use_current_item()
 			get_viewport().set_input_as_handled()
+		return
+
+	if event is InputEventKey and event.is_pressed() and not event.is_echo():
+		var key_code = event.keycode
+		if key_code >= KEY_1 and key_code <= KEY_9:
+			inventory_ui.select_slot(key_code - KEY_1)
+			get_viewport().set_input_as_handled()
+		elif key_code == KEY_0:
+			inventory_ui.select_slot(9)
+			get_viewport().set_input_as_handled()
 
 func _physics_process(delta):
 	var input_vector = Vector2(

--- a/scripts/ui/InventoryUI.gd
+++ b/scripts/ui/InventoryUI.gd
@@ -73,15 +73,20 @@ func _update_display():
 
 func _on_slot_gui_input(event: InputEvent, slot_index: int):
     if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.is_pressed():
-        # If clicking the already selected slot, deselect it
-        if selected_slot == slot_index:
-            selected_slot = -1
-            item_selected.emit(null)
-        else:
-            selected_slot = slot_index
-            item_selected.emit(inventory.items[selected_slot])
+        select_slot(slot_index)
 
-        _update_selection_visuals()
+func select_slot(slot_index: int):
+    if slot_index < 0 or slot_index >= inventory.items.size():
+        return
+
+    if selected_slot == slot_index:
+        selected_slot = -1
+        item_selected.emit(null)
+    else:
+        selected_slot = slot_index
+        item_selected.emit(inventory.items[slot_index])
+
+    _update_selection_visuals()
 
 func _update_selection_visuals():
     for i in range(grid_container.get_child_count()):


### PR DESCRIPTION
This commit adds the ability for the player to select items from their inventory using the number keys (1-9 and 0).

- Added a `select_slot(slot_index)` function to `InventoryUI.gd` to allow programmatic selection of inventory slots.
- Modified the player script to listen for number key presses and call the new `select_slot` function accordingly.
- Key 1 selects the first slot, 2 the second, and so on, with 0 selecting the tenth slot.